### PR TITLE
XWiki Version: Enterprise 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ This package is designed to deploy XWiki environment which represents a professi
 
 Layer                |     Server    | Number of CTs <br/> by default | Cloudlets per CT <br/> (reserved/dynamic) | Options
 -------------------- | --------------| :----------------------------: | :---------------------------------------: | :-----:
-AS                   | Apache 2 (MOD_PHP) |       1                        |           1 / 16                          | -
+AS                   |   Tomcat 7    |       1                        |           1 / 16                          | -
 DB                   |    MySQL      |       1                        |           1 / 16                           | -
 
 * AS - Application server 
 * DB - Database 
 * CT - Container
 
-**XWiki Version**: Enterprise 7.2-milestone-1<br/>
+**XWiki Version**: Enterprise 8.2.1<br/>
 **Tomcat Version**: 7.0.67<br/>
-**Java Engine**: Java 7<br/>
+**Java Engine**: Java 8<br/>
 **MySQL Database**: 5.7.12
 
 ### Deployment

--- a/dumps/xwiki-enterprise-web-7.2-milestone-1.war
+++ b/dumps/xwiki-enterprise-web-7.2-milestone-1.war
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27b22dc9713132dadc60af56877e5961b5cbbdf42a31a37836854abdd4d5d6c5
-size 226146353

--- a/manifest.jps
+++ b/manifest.jps
@@ -4,7 +4,7 @@
 	"application": {
 		"id": "xwiki",
 		"name": "XWiki",
-		"version": "7.2",
+		"version": "8.2",
 		"logo": "https://raw.githubusercontent.com/jelastic-jps/xwiki/master/images/xwiki_logo.png",
 		"type": "java",
 		"homepage": "http://www.xwiki.org/",
@@ -17,7 +17,7 @@
 		"env": {
 			"topology": {
 				"ha": false,
-				"engine": "java7",
+				"engine": "java8",
 				"ssl": false,
 				"nodes": [{
 						"extip": false,
@@ -39,8 +39,8 @@
 				}
 			],
 			"deployments": [{
-					"archive": "https://media.githubusercontent.com/media/jelastic-jps/xwiki/master/dumps/xwiki-enterprise-web-7.2-milestone-1.war",
-					"name": "xwiki-enterprise-web-7.2.war",
+					"archive": "https://media.githubusercontent.com/media/jelastic-jps/xwiki/master/dumps/xwiki-8.2.war",
+					"name": "xwiki-8.2.war",
 					"context": "ROOT"
 				}
 			],

--- a/manifest.jps
+++ b/manifest.jps
@@ -39,7 +39,7 @@
 				}
 			],
 			"deployments": [{
-					"archive": "https://media.githubusercontent.com/media/jelastic-jps/xwiki/master/dumps/xwiki-8.2.war",
+					"archive": "http://download.forge.ow2.org/xwiki/xwiki-enterprise-web-8.2.1.war",
 					"name": "xwiki-8.2.war",
 					"context": "ROOT"
 				}


### PR DESCRIPTION
replaced very outdated 7.2 with 8.2.1.

7.2 has some issues with displaying menus http://jira.xwiki.org/browse/XWIKI-13337 and doesn't really work correctly without manual intervention.
